### PR TITLE
E2E tests for custom status

### DIFF
--- a/app/components/custom_status/clear_button.tsx
+++ b/app/components/custom_status/clear_button.tsx
@@ -12,15 +12,17 @@ interface Props {
     handlePress: () => void;
     size?: number;
     theme: Theme;
+    testID?: string;
 }
 
 const ClearButton = (props: Props) => {
-    const {handlePress, size, theme} = props;
+    const {handlePress, size, theme, testID} = props;
     const style = getStyleSheet(theme);
 
     return (
         <View
             style={style.container}
+            testID={testID}
         >
             <CompassIcon
                 onPress={preventDoubleTap(handlePress)}

--- a/app/components/custom_status/custom_status_emoji.tsx
+++ b/app/components/custom_status/custom_status_emoji.tsx
@@ -5,15 +5,17 @@ import {makeGetCustomStatus, isCustomStatusEnabled} from '@selectors/custom_stat
 import {useSelector} from 'react-redux';
 import {GlobalState} from '@mm-redux/types/store';
 import Emoji from '@components/emoji';
+import {Text, TextStyle} from 'react-native';
 
 interface ComponentProps {
     emojiSize?: number;
     userID?: string;
+    style?: TextStyle
 }
 
 const CustomStatusEmoji = (props: ComponentProps) => {
     const getCustomStatus = makeGetCustomStatus();
-    const {emojiSize, userID} = props;
+    const {emojiSize, userID, style} = props;
     const customStatusEnabled = useSelector(isCustomStatusEnabled);
     const customStatus = useSelector((state: GlobalState) => {
         return getCustomStatus(state, userID);
@@ -24,10 +26,15 @@ const CustomStatusEmoji = (props: ComponentProps) => {
     }
 
     return (
-        <Emoji
-            size={emojiSize}
-            emojiName={customStatus.emoji}
-        />
+        <Text
+            style={style}
+            testID={`custom_status_emoji.${customStatus.emoji}`}
+        >
+            <Emoji
+                size={emojiSize}
+                emojiName={customStatus.emoji}
+            />
+        </Text>
     );
 };
 

--- a/app/components/custom_status/custom_status_emoji.tsx
+++ b/app/components/custom_status/custom_status_emoji.tsx
@@ -10,12 +10,13 @@ import {Text, TextStyle} from 'react-native';
 interface ComponentProps {
     emojiSize?: number;
     userID?: string;
-    style?: TextStyle
+    style?: TextStyle;
+    testID?: string;
 }
 
 const CustomStatusEmoji = (props: ComponentProps) => {
     const getCustomStatus = makeGetCustomStatus();
-    const {emojiSize, userID, style} = props;
+    const {emojiSize, userID, style, testID} = props;
     const customStatusEnabled = useSelector(isCustomStatusEnabled);
     const customStatus = useSelector((state: GlobalState) => {
         return getCustomStatus(state, userID);
@@ -25,10 +26,11 @@ const CustomStatusEmoji = (props: ComponentProps) => {
         return null;
     }
 
+    const testIdPrefix = testID ? `${testID}.` : '';
     return (
         <Text
             style={style}
-            testID={`custom_status_emoji.${customStatus.emoji}`}
+            testID={`${testIdPrefix}custom_status_emoji.${customStatus.emoji}`}
         >
             <Emoji
                 size={emojiSize}

--- a/app/components/post_header/post_header.js
+++ b/app/components/post_header/post_header.js
@@ -203,6 +203,7 @@ export default class PostHeader extends PureComponent {
                     </TouchableWithFeedback>
                     <CustomStatusEmoji
                         userID={post.user_id}
+                        style={{color: theme.centerChannelColor}}
                     />
                 </>
             );
@@ -331,7 +332,10 @@ export default class PostHeader extends PureComponent {
         return (
             <React.Fragment>
                 <View style={[style.container, (isPendingOrFailedPost && style.pendingPost)]}>
-                    <View style={style.wrapper}>
+                    <View
+                        style={style.wrapper}
+                        testID='post_header'
+                    >
                         {this.renderDisplayName()}
                         {this.renderTag()}
                         {dateComponent}

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.js
@@ -181,6 +181,7 @@ export default class ChannelItem extends PureComponent {
                 <CustomStatusEmoji
                     userID={this.props.teammateId}
                     style={[{color: changeOpacity(theme.sidebarText, 0.6)}, extraTextStyle]}
+                    testID={displayName}
                 />
             ) : null;
 

--- a/app/components/sidebars/main/channels_list/channel_item/channel_item.js
+++ b/app/components/sidebars/main/channels_list/channel_item/channel_item.js
@@ -178,13 +178,10 @@ export default class ChannelItem extends PureComponent {
 
         const customStatus = this.props.teammateId ?
             (
-                <Text
+                <CustomStatusEmoji
+                    userID={this.props.teammateId}
                     style={[{color: changeOpacity(theme.sidebarText, 0.6)}, extraTextStyle]}
-                >
-                    <CustomStatusEmoji
-                        userID={this.props.teammateId}
-                    />
-                </Text>
+                />
             ) : null;
 
         return (

--- a/app/components/sidebars/settings/settings_sidebar_base.js
+++ b/app/components/sidebars/settings/settings_sidebar_base.js
@@ -217,26 +217,31 @@ export default class SettingsSidebarBase extends PureComponent {
                 theme={theme}
             />
         ) : null;
-        const customStatusEmoji = isStatusSet ?
-            (
-                <Emoji
-                    emojiName={customStatus.emoji}
-                    size={20}
-                />
-            ) :
-            (
-                <CompassIcon
-                    name='emoticon-happy-outline'
-                    size={24}
-                    style={{color: changeOpacity(theme.centerChannelColor, 0.64)}}
-                />
-            );
+        const customStatusEmoji = (
+            <View
+                testID={`custom_status.emoji.${isStatusSet ? customStatus.emoji : 'default'}`}
+            >
+                {isStatusSet ? (
+                    <Emoji
+                        emojiName={customStatus.emoji}
+                        size={20}
+                    />
+                ) : (
+                    <CompassIcon
+                        name='emoticon-happy-outline'
+                        size={24}
+                        style={{color: changeOpacity(theme.centerChannelColor, 0.64)}}
+                    />
+                )}
+            </View>
+        );
 
         const clearButton = isStatusSet ?
             (
                 <ClearButton
                     handlePress={preventDoubleTap(this.props.actions.unsetCustomStatus)}
                     theme={theme}
+                    testID='settings.sidebar.custom_status.action.clear'
                 />
             ) : null;
 

--- a/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
+++ b/app/screens/channel/channel_nav_bar/channel_title/channel_title.js
@@ -156,12 +156,11 @@ export default class ChannelTitle extends PureComponent {
 
         const customStatus = this.props.channelType === General.DM_CHANNEL ?
             (
-                <Text style={[style.icon, style.emoji]}>
-                    <CustomStatusEmoji
-                        userID={this.props.teammateId}
-                        emojiSize={18}
-                    />
-                </Text>
+                <CustomStatusEmoji
+                    userID={this.props.teammateId}
+                    emojiSize={18}
+                    style={[style.icon, style.emoji]}
+                />
             ) : null;
 
         if (customStatus) {

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -182,12 +182,12 @@ export default class ChannelInfoHeader extends React.PureComponent {
                 </View>
                 {isCustomStatusEnabled && type === General.DM_CHANNEL && customStatus.emoji &&
                     <View style={[style.row, style.customStatusContainer]}>
-                        <View style={style.iconContainer}>
+                        <Text style={style.iconContainer}>
                             <Emoji
                                 emojiName={customStatus.emoji}
                                 size={20}
                             />
-                        </View>
+                        </Text>
                         <Text
                             style={[style.channelName, style.customStatusText]}
                             ellipsizeMode='tail'
@@ -289,6 +289,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         iconContainer: {
             marginRight: 8,
+            color: theme.centerChannelColor,
         },
         customStatusContainer: {
             position: 'relative',

--- a/app/screens/channel_info/channel_info_header.js
+++ b/app/screens/channel_info/channel_info_header.js
@@ -181,8 +181,14 @@ export default class ChannelInfoHeader extends React.PureComponent {
                     </Text>
                 </View>
                 {isCustomStatusEnabled && type === General.DM_CHANNEL && customStatus.emoji &&
-                    <View style={[style.row, style.customStatusContainer]}>
-                        <Text style={style.iconContainer}>
+                    <View
+                        style={[style.row, style.customStatusContainer]}
+                        testID={`${testID}.custom_status`}
+                    >
+                        <Text
+                            style={style.iconContainer}
+                            testID={`custom_status.emoji.${customStatus.emoji}`}
+                        >
                             <Emoji
                                 emojiName={customStatus.emoji}
                                 size={20}

--- a/app/screens/custom_status/custom_status_modal.tsx
+++ b/app/screens/custom_status/custom_status_modal.tsx
@@ -54,6 +54,7 @@ type State = {
 class CustomStatusModal extends NavigationComponent<Props, State> {
     rightButton: OptionsTopBarButton = {
         id: 'update-custom-status',
+        testID: 'custom_status.done_button',
         enabled: true,
         showAsAction: 'always',
     };
@@ -151,7 +152,7 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
         return (
             <>
                 <View style={style.separator}/>
-                <View >
+                <View testID='custom_status.recents'>
                     <Text style={style.title}>
                         {this.props.intl.formatMessage({
                             id: 'custom_status.suggestions.recent_title',
@@ -194,7 +195,7 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
         return (
             <>
                 <View style={style.separator}/>
-                <View>
+                <View testID='custom_status.suggestions'>
                     <Text style={style.title}>
                         {this.props.intl.formatMessage({
                             id: 'custom_status.suggestions.title',
@@ -239,6 +240,7 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
         const style = getStyleSheet(theme);
         const customStatusEmoji = (
             <TouchableOpacity
+                testID={`custom_status.emoji.${isStatusSet ? (emoji || 'speech_balloon') : 'default'}`}
                 onPress={this.openEmojiPicker}
                 style={style.emoji}
             >
@@ -260,6 +262,7 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
         const customStatusInput = (
             <View style={style.inputContainer}>
                 <TextInput
+                    testID='custom_status.input'
                     value={text}
                     placeholder={this.props.intl.formatMessage({id: 'custom_status.set_status', defaultMessage: 'Set a Status'})}
                     placeholderTextColor={changeOpacity(theme.centerChannelColor, 0.5)}
@@ -276,7 +279,10 @@ class CustomStatusModal extends NavigationComponent<Props, State> {
                 />
                 {customStatusEmoji}
                 {isStatusSet ? (
-                    <View style={style.clearButton}>
+                    <View
+                        style={style.clearButton}
+                        testID='custom_status.clear_input'
+                    >
                         <ClearButton
                             handlePress={this.clearHandle}
                             theme={theme}

--- a/app/screens/custom_status/custom_status_suggestion.tsx
+++ b/app/screens/custom_status/custom_status_suggestion.tsx
@@ -34,12 +34,13 @@ const CustomStatusSuggestion = (props: Props) => {
             <ClearButton
                 handlePress={() => handleClear({emoji, text})}
                 theme={theme}
+                testID='custom_status_suggestion.clear_button'
             />
         ) : null;
 
     return (
         <TouchableOpacity
-            testID={'custom_status.status_suggestion'}
+            testID={`custom_status_suggestion.${text}`}
             onPress={handleClick}
         >
             <View style={style.container}>

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -186,15 +186,20 @@ export default class UserProfile extends PureComponent {
 
         const label = formatMessage({id: 'user.settings.general.status', defaultMessage: 'Status'});
         return (
-            <View>
+            <View
+                testID='user_profile.custom_status'
+            >
                 <Text style={style.header}>{label}</Text>
                 <View style={style.customStatus}>
-                    <View style={style.iconContainer}>
+                    <Text
+                        style={style.iconContainer}
+                        testID={`custom_status.emoji.${customStatus.emoji}`}
+                    >
                         <Emoji
                             emojiName={customStatus.emoji}
                             size={20}
                         />
-                    </View>
+                    </Text>
                     <Text style={[style.text, style.customStatusText]}>{customStatus.text}</Text>
                     {isMyUser && (
                         <View style={style.clearButton}>
@@ -371,7 +376,10 @@ export default class UserProfile extends PureComponent {
         }
 
         return (
-            <SafeAreaView style={style.container}>
+            <SafeAreaView
+                style={style.container}
+                testID='user_profile.screen'
+            >
                 <StatusBar/>
                 <ScrollView
                     style={style.scrollView}
@@ -414,6 +422,7 @@ const createStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         iconContainer: {
             marginRight: 5,
+            color: theme.centerChannelColor,
         },
         customStatus: {
             position: 'relative',

--- a/app/screens/user_profile/user_profile.js
+++ b/app/screens/user_profile/user_profile.js
@@ -384,6 +384,7 @@ export default class UserProfile extends PureComponent {
                 <ScrollView
                     style={style.scrollView}
                     contentContainerStyle={style.contentContainer}
+                    testID='user_profile.scroll_view'
                 >
                     <View style={style.top}>
                         <ProfilePicture
@@ -407,6 +408,7 @@ export default class UserProfile extends PureComponent {
                         iconSize={24}
                         textId={t('mobile.routes.user_profile.send_message')}
                         theme={theme}
+                        testID='user_profile.row.send_message'
                     />
                     {this.renderAdditionalOptions()}
                 </ScrollView>

--- a/app/screens/user_profile/user_profile_row.js
+++ b/app/screens/user_profile/user_profile_row.js
@@ -48,16 +48,19 @@ const createStyleSheet = makeStyleSheetFromTheme((theme) => {
     };
 });
 
-function createTouchableComponent(children, action) {
+function createTouchableComponent(children, action, testID) {
     return (
-        <TouchableWithFeedback onPress={action}>
+        <TouchableWithFeedback
+            onPress={action}
+            testID={testID}
+        >
             {children}
         </TouchableWithFeedback>
     );
 }
 
 function userProfileRow(props) {
-    const {action, defaultMessage, detail, icon, textId, togglable, theme, iconSize, shouldRender = true} = props;
+    const {action, defaultMessage, detail, icon, textId, togglable, theme, iconSize, shouldRender = true, testID} = props;
 
     if (!shouldRender) {
         return null;
@@ -97,7 +100,7 @@ function userProfileRow(props) {
         return RowComponent;
     }
 
-    return createTouchableComponent(RowComponent, action);
+    return createTouchableComponent(RowComponent, action, testID);
 }
 
 userProfileRow.propTypes = {
@@ -115,6 +118,7 @@ userProfileRow.propTypes = {
     togglable: PropTypes.bool,
     textColor: PropTypes.string,
     theme: PropTypes.object.isRequired,
+    testID: PropTypes.string,
 };
 
 userProfileRow.defaultProps = {
@@ -122,6 +126,7 @@ userProfileRow.defaultProps = {
     iconSize: 15,
     textColor: '#000',
     togglable: false,
+    testID: 'user_profile.row',
 };
 
 export default userProfileRow;

--- a/detox/e2e/support/server_api/default_config.json
+++ b/detox/e2e/support/server_api/default_config.json
@@ -90,6 +90,7 @@
         "EnableUserCreation": true,
         "EnableOpenServer": true,
         "EnableUserDeactivation": false,
+        "EnableCustomUserStatuses": false,
         "RestrictCreationToDomains": "",
         "EnableCustomBrand": false,
         "CustomBrandText": "",

--- a/detox/e2e/support/ui/component/settings_sidebar.js
+++ b/detox/e2e/support/ui/component/settings_sidebar.js
@@ -15,6 +15,8 @@ class SettingsSidebar {
         editProfileAction: 'settings.sidebar.edit_profile.action',
         settingsAction: 'settings.sidebar.settings.action',
         logoutAction: 'settings.sidebar.logout.action',
+        customStatusAction: 'settings.sidebar.custom_status.action',
+        customStatusClearButton: 'settings.sidebar.custom_status.action.clear',
     }
 
     settingsSidebar = element(by.id(this.testID.settingsSidebar));
@@ -25,6 +27,8 @@ class SettingsSidebar {
     editProfileAction = element(by.id(this.testID.editProfileAction));
     settingsAction = element(by.id(this.testID.settingsAction));
     logoutAction = element(by.id(this.testID.logoutAction));
+    customStatusAction = element(by.id(this.testID.customStatusAction));
+    customStatusClearButton = element(by.id(this.testID.customStatusClearButton));
 
     getUserStatus(userStatus) {
         const userStatusIconTestID = `${this.testID.userStatusIconPrefix}${userStatus}`;
@@ -77,6 +81,11 @@ class SettingsSidebar {
 
     tapLogoutAction = async () => {
         await this.logoutAction.tap();
+        await expect(this.settingsSidebar).not.toBeVisible();
+    }
+
+    tapCustomStatusAction = async () => {
+        await this.customStatusAction.tap();
         await expect(this.settingsSidebar).not.toBeVisible();
     }
 }

--- a/detox/e2e/support/ui/screen/channel_info.js
+++ b/detox/e2e/support/ui/screen/channel_info.js
@@ -12,6 +12,7 @@ class ChannelInfoScreen {
         closeChannelInfoButton: 'close.channel_info.button',
         headerChannelIconGMMemberCount: 'channel_info.header.channel_icon.gm_member_count',
         headerDisplayName: 'channel_info.header.display_name',
+        headerCustomStatus: 'channel_info.header.custom_status',
         favoritePreferenceAction: 'channel_info.favorite.action',
         favoriteSwitchFalse: 'channel_info.favorite.action.switch.false',
         favoriteSwitchTrue: 'channel_info.favorite.action.switch.true',

--- a/detox/e2e/support/ui/screen/custom_status.js
+++ b/detox/e2e/support/ui/screen/custom_status.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {SettingsSidebar} from '@support/ui/component';
+
+class CustomStatusScreen {
+    testID = {
+        customStatusScreen: 'custom_status.screen',
+        input: 'custom_status.input',
+        selectedEmojiPrefix: 'custom_status.emoji.',
+        clearInputButton: 'custom_status.clear_input',
+        doneButton: 'custom_status.done_button',
+    }
+
+    customStatusScreen = element(by.id(this.testID.customStatusScreen));
+    input = element(by.id(this.testID.input));
+    clearInputButton = element(by.id(this.testID.clearInputButton))
+    doneButton = element(by.id(this.testID.doneButton))
+
+    getCustomStatusSelectedEmoji = (emoji) => {
+        const emojiTestID = `${this.testID.selectedEmojiPrefix}${emoji}`;
+        return element(by.id(emojiTestID));
+    }
+
+    toBeVisible = async () => {
+        await expect(this.customStatusScreen).toBeVisible();
+
+        return this.customStatusScreen;
+    }
+
+    open = async () => {
+        // # Open custom status screen
+        await SettingsSidebar.tapCustomStatusAction();
+
+        return this.toBeVisible();
+    }
+
+    tapSuggestion = async ({emoji, text}) => {
+        await element(by.text(text).withAncestor(by.id('custom_status.suggestions'))).tap();
+
+        await expect(this.input).toHaveText(text);
+        await expect(this.getCustomStatusSelectedEmoji(emoji)).toBeVisible();
+    }
+
+    close = async () => {
+        await this.doneButton.tap();
+        return expect(this.customStatusScreen).not.toBeVisible();
+    }
+}
+
+const customStatusScreen = new CustomStatusScreen();
+export default customStatusScreen;

--- a/detox/e2e/support/ui/screen/custom_status.js
+++ b/detox/e2e/support/ui/screen/custom_status.js
@@ -9,6 +9,8 @@ class CustomStatusScreen {
         selectedEmojiPrefix: 'custom_status.emoji.',
         clearInputButton: 'custom_status.clear_input',
         doneButton: 'custom_status.done_button',
+        suggestionPrefix: 'custom_status_suggestion.',
+        suggestionClearButton: 'custom_status_suggestion.clear_button',
     }
 
     customStatusScreen = element(by.id(this.testID.customStatusScreen));
@@ -19,6 +21,16 @@ class CustomStatusScreen {
     getCustomStatusSelectedEmoji = (emoji) => {
         const emojiTestID = `${this.testID.selectedEmojiPrefix}${emoji}`;
         return element(by.id(emojiTestID));
+    }
+
+    getCustomStatusSuggestion = (text) => {
+        const suggestionID = `${this.testID.suggestionPrefix}${text}`;
+        return element(by.id(suggestionID));
+    }
+
+    getSuggestionClearButton = (text) => {
+        const suggestionID = `${this.testID.suggestionPrefix}${text}`;
+        return element(by.id(this.testID.suggestionClearButton).withAncestor(by.id(suggestionID)));
     }
 
     toBeVisible = async () => {
@@ -35,7 +47,7 @@ class CustomStatusScreen {
     }
 
     tapSuggestion = async ({emoji, text}) => {
-        await element(by.text(text).withAncestor(by.id('custom_status.suggestions'))).tap();
+        await this.getCustomStatusSuggestion(text).tap();
 
         await expect(this.input).toHaveText(text);
         await expect(this.getCustomStatusSelectedEmoji(emoji)).toBeVisible();

--- a/detox/e2e/support/ui/screen/index.js
+++ b/detox/e2e/support/ui/screen/index.js
@@ -29,6 +29,7 @@ import SearchScreen from './search';
 import SelectServerScreen from './select_server';
 import SelectTeamScreen from './select_team';
 import ThreadScreen from './thread';
+import UserProfileScreen from './user_profile';
 
 export {
     AddReactionScreen,
@@ -59,4 +60,5 @@ export {
     SelectServerScreen,
     SelectTeamScreen,
     ThreadScreen,
+    UserProfileScreen,
 };

--- a/detox/e2e/support/ui/screen/index.js
+++ b/detox/e2e/support/ui/screen/index.js
@@ -7,6 +7,7 @@ import ChannelNotificationPreferenceScreen from './channel_notification_preferen
 import ChannelScreen from './channel';
 import ClockDisplaySettingsScreen from './clock_display_settings';
 import CreateChannelScreen from './create_channel';
+import CustomStatusScreen from './custom_status';
 import DisplaySettingsScreen from './display_settings';
 import EditChannelScreen from './edit_channel';
 import EditPostScreen from './edit_post';
@@ -36,6 +37,7 @@ export {
     ChannelScreen,
     ClockDisplaySettingsScreen,
     CreateChannelScreen,
+    CustomStatusScreen,
     DisplaySettingsScreen,
     EditChannelScreen,
     EditPostScreen,

--- a/detox/e2e/support/ui/screen/user_profile.js
+++ b/detox/e2e/support/ui/screen/user_profile.js
@@ -5,15 +5,19 @@ import {SettingsSidebar} from '@support/ui/component';
 class UserProfileScreen {
     testID = {
         userProfileScreen: 'user_profile.screen',
+        scrollView: 'user_profile.scroll_view',
         customStatus: 'user_profile.custom_status',
         profilePicture: 'user_profile.profile_picture',
         closeUserProfileButton: 'close.settings.button',
+        sendMessageButton: 'user_profile.row.send_message',
     }
 
     userProfileScreen = element(by.id(this.testID.userProfileScreen));
+    scrollView = element(by.id(this.testID.scrollView))
     customStatus = element(by.id(this.testID.customStatus));
     profilePicture = element(by.id(this.testID.profilePicture))
     closeUserProfileButton = element(by.id(this.testID.closeUserProfileButton))
+    sendMessageButton = element(by.id(this.testID.sendMessageButton))
 
     toBeVisible = async () => {
         await expect(this.userProfileScreen).toBeVisible();

--- a/detox/e2e/support/ui/screen/user_profile.js
+++ b/detox/e2e/support/ui/screen/user_profile.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {SettingsSidebar} from '@support/ui/component';
+
+class UserProfileScreen {
+    testID = {
+        userProfileScreen: 'user_profile.screen',
+        customStatus: 'user_profile.custom_status',
+        profilePicture: 'user_profile.profile_picture',
+        closeUserProfileButton: 'close.settings.button',
+    }
+
+    userProfileScreen = element(by.id(this.testID.userProfileScreen));
+    customStatus = element(by.id(this.testID.customStatus));
+    profilePicture = element(by.id(this.testID.profilePicture))
+    closeUserProfileButton = element(by.id(this.testID.closeUserProfileButton))
+
+    toBeVisible = async () => {
+        await expect(this.userProfileScreen).toBeVisible();
+
+        return this.userProfileScreen;
+    }
+
+    open = async () => {
+        // # Open custom status screen
+        await SettingsSidebar.userInfoAction.tap();
+
+        return this.toBeVisible();
+    }
+
+    close = async () => {
+        await this.closeUserProfileButton.tap();
+        return expect(this.userProfileScreen).not.toBeVisible();
+    }
+}
+
+const userProfileScreen = new UserProfileScreen();
+export default userProfileScreen;

--- a/detox/e2e/test/smoke_test/custom_status.e2e.js
+++ b/detox/e2e/test/smoke_test/custom_status.e2e.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {ChannelScreen, CustomStatusScreen, UserProfileScreen, ThreadScreen, MoreDirectMessagesScreen} from '@support/ui/screen';
+import {ChannelScreen, CustomStatusScreen, UserProfileScreen, ThreadScreen, ChannelInfoScreen} from '@support/ui/screen';
 import {
     Setup,
     System,
@@ -193,27 +193,47 @@ describe('Custom status', () => {
         await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
         await ChannelScreen.closeSettingsSidebar();
 
+        // # Post a message and check if custom status emoji is present in the post header
         await ChannelScreen.postMessage(message);
         await expect(element(by.id(`custom_status_emoji.${customStatus.emojiName}`).withAncestor(by.id('post_header')))).toBeVisible();
 
+        // # Open the reply thread for the last post
         const {post} = await Post.apiGetLastPostInChannel(testChannel.id);
         await ChannelScreen.openReplyThreadFor(post.id, message);
+
+        // * Check if the custom status emoji is present in the post header and close thread
         await expect(element(by.id(`custom_status_emoji.${customStatus.emojiName}`).withAncestor(by.id('post_header')))).toBeVisible();
         await ThreadScreen.back();
 
         await openSettingsSidebar();
+
+        // # Open user profile screen
         await UserProfileScreen.open();
         await UserProfileScreen.toBeVisible();
+
+        // * Check if custom status is present in the user profile screen
         await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
         await expect(element(by.text(customStatus.text).withAncestor(by.id(UserProfileScreen.testID.customStatus)))).toBeVisible();
-        await UserProfileScreen.close();
 
+        // # Scroll to bottom and tap the Send Message button to open the direct message channel
+        await UserProfileScreen.scrollView.scrollTo('bottom');
+        await UserProfileScreen.sendMessageButton.tap();
+
+        // # Open main sidebar and check if custom status emoji is present next to the username in the Direct messages section
         await ChannelScreen.openMainSidebar();
-        await MoreDirectMessagesScreen.open();
-        await MoreDirectMessagesScreen.searchInput.typeText(testUser.username);
-        await MoreDirectMessagesScreen.getUserAtIndex(0).tap();
+        expect(element(by.id(`${testUser.username}.custom_status_emoji.${customStatus.emojiName}`))).toBeVisible();
+        await ChannelScreen.closeMainSidebar();
 
+        // * Check if the custom status emoji is present in the channel title
         await expect(element(by.id(`custom_status_emoji.${customStatus.emojiName}`).withAncestor(by.id('channel.title.button')))).toBeVisible();
+
+        // # Open the channel info screen
+        await ChannelInfoScreen.open();
+
+        // * Check if the custom status is present in the channel info screen and then close the screen
+        await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
+        await expect(element(by.text(customStatus.text).withAncestor(by.id(ChannelInfoScreen.testID.headerCustomStatus)))).toBeVisible();
+        await ChannelInfoScreen.close();
     });
 });
 

--- a/detox/e2e/test/smoke_test/custom_status.e2e.js
+++ b/detox/e2e/test/smoke_test/custom_status.e2e.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import {ChannelScreen, CustomStatusScreen} from '@support/ui/screen';
+import {
+    Setup,
+    System,
+} from '@support/server_api';
+import {SettingsSidebar} from '@support/ui/component';
+
+describe('Custom status', () => {
+    beforeAll(async () => {
+        await System.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
+    });
+
+    beforeEach(async () => {
+        const {user} = await Setup.apiInit();
+
+        // # Open channel screen
+        await ChannelScreen.open(user);
+    });
+
+    afterEach(async () => {
+        await ChannelScreen.logout();
+    });
+
+    const defaultCustomStatuses = ['In a meeting', 'Out for lunch', 'Out sick', 'Working from home', 'On a vacation'];
+    const {
+        openSettingsSidebar,
+    } = ChannelScreen;
+
+    test('MM-T3890 Setting a custom status', async () => {
+        const customStatus = {
+            emoji: 'calendar',
+            text: 'In a meeting',
+        };
+
+        await openSettingsSidebar();
+        await CustomStatusScreen.open();
+        const isSuggestionPresentPromiseArray = [];
+        defaultCustomStatuses.map(async (text) => {
+            isSuggestionPresentPromiseArray.push(expect(element(by.text(text))).toBeVisible());
+        });
+
+        await Promise.all(isSuggestionPresentPromiseArray);
+
+        await CustomStatusScreen.tapSuggestion(customStatus);
+
+        await CustomStatusScreen.tapSuggestion(customStatus);
+
+        await CustomStatusScreen.close();
+
+        await openSettingsSidebar();
+        await expect(element(by.text(customStatus.text))).toBeVisible();
+        await expect(element(by.id(`custom_status.emoji.${customStatus.emoji}`))).toBeVisible();
+
+        await CustomStatusScreen.open();
+        await CustomStatusScreen.close();
+    });
+
+    test.only('MM-T3891 Setting your own custom status', async () => {
+        const customStatus = {
+            emoji: '😀',
+            emojiName: 'grinning',
+            text: 'Watering plants',
+        };
+
+        await openSettingsSidebar();
+        await CustomStatusScreen.open();
+
+        await CustomStatusScreen.input.typeText(customStatus.text);
+        await expect(CustomStatusScreen.getCustomStatusSelectedEmoji('speech_balloon')).toBeVisible();
+        await CustomStatusScreen.getCustomStatusSelectedEmoji('speech_balloon').multiTap(2);
+
+        await expect(element(by.id('add_reaction.screen'))).toBeVisible();
+
+        await expect(element(by.text(customStatus.emoji))).toBeVisible();
+        await element(by.text(customStatus.emoji)).tap();
+
+        await expect(element(by.id('add_reaction.screen'))).not.toBeVisible();
+        await expect(CustomStatusScreen.getCustomStatusSelectedEmoji(customStatus.emojiName)).toBeVisible();
+
+        await CustomStatusScreen.close();
+
+        await openSettingsSidebar();
+        await expect(element(by.text(customStatus.text).withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
+
+        await SettingsSidebar.customStatusClearButton.tap();
+        await expect(element(by.text(customStatus.text).withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).not.toBeVisible();
+    });
+});

--- a/detox/e2e/test/smoke_test/custom_status.e2e.js
+++ b/detox/e2e/test/smoke_test/custom_status.e2e.js
@@ -7,6 +7,8 @@ import {
 } from '@support/server_api';
 import {SettingsSidebar} from '@support/ui/component';
 
+const {openSettingsSidebar} = ChannelScreen;
+
 describe('Custom status', () => {
     beforeAll(async () => {
         await System.apiUpdateConfig({TeamSettings: {EnableCustomUserStatuses: true}});
@@ -24,68 +26,181 @@ describe('Custom status', () => {
     });
 
     const defaultCustomStatuses = ['In a meeting', 'Out for lunch', 'Out sick', 'Working from home', 'On a vacation'];
-    const {
-        openSettingsSidebar,
-    } = ChannelScreen;
+
+    const defaultStatus = {
+        emoji: 'calendar',
+        text: 'In a meeting',
+    };
+
+    const customStatus = {
+        emoji: '😀',
+        emojiName: 'grinning',
+        text: 'Watering plants',
+    };
 
     test('MM-T3890 Setting a custom status', async () => {
-        const customStatus = {
-            emoji: 'calendar',
-            text: 'In a meeting',
-        };
-
         await openSettingsSidebar();
+
+        // # Click on the Set a custom status option and check if the modal opens
         await CustomStatusScreen.open();
         const isSuggestionPresentPromiseArray = [];
         defaultCustomStatuses.map(async (text) => {
-            isSuggestionPresentPromiseArray.push(expect(element(by.text(text))).toBeVisible());
+            // * Check if all the default suggestions are visible
+            isSuggestionPresentPromiseArray.push(expect(CustomStatusScreen.getCustomStatusSuggestion(text)).toBeVisible());
         });
 
         await Promise.all(isSuggestionPresentPromiseArray);
 
-        await CustomStatusScreen.tapSuggestion(customStatus);
+        // * Tap a suggestion and check if it is selected
+        await CustomStatusScreen.tapSuggestion(defaultStatus);
 
-        await CustomStatusScreen.tapSuggestion(customStatus);
+        // * Tap again and check if it is selected again
+        await CustomStatusScreen.tapSuggestion(defaultStatus);
 
+        // # Click on Done button and check if the modal closes
         await CustomStatusScreen.close();
 
         await openSettingsSidebar();
-        await expect(element(by.text(customStatus.text))).toBeVisible();
-        await expect(element(by.id(`custom_status.emoji.${customStatus.emoji}`))).toBeVisible();
 
+        // * Check if the selected emoji and text are visible in the sidebar
+        await expect(element(by.text(defaultStatus.text))).toBeVisible();
+        await expect(element(by.id(`custom_status.emoji.${defaultStatus.emoji}`))).toBeVisible();
+
+        // # Click on the Set a custom status option and check if the modal opens
         await CustomStatusScreen.open();
         await CustomStatusScreen.close();
     });
 
-    test.only('MM-T3891 Setting your own custom status', async () => {
-        const customStatus = {
-            emoji: '😀',
-            emojiName: 'grinning',
-            text: 'Watering plants',
-        };
-
+    test('MM-T3891 Setting your own custom status', async () => {
+        // # Open custom status modal and close it after setting the status
+        await openCustomStatusModalAndSetStatus(customStatus);
         await openSettingsSidebar();
-        await CustomStatusScreen.open();
 
-        await CustomStatusScreen.input.typeText(customStatus.text);
-        await expect(CustomStatusScreen.getCustomStatusSelectedEmoji('speech_balloon')).toBeVisible();
-        await CustomStatusScreen.getCustomStatusSelectedEmoji('speech_balloon').multiTap(2);
-
-        await expect(element(by.id('add_reaction.screen'))).toBeVisible();
-
-        await expect(element(by.text(customStatus.emoji))).toBeVisible();
-        await element(by.text(customStatus.emoji)).tap();
-
-        await expect(element(by.id('add_reaction.screen'))).not.toBeVisible();
-        await expect(CustomStatusScreen.getCustomStatusSelectedEmoji(customStatus.emojiName)).toBeVisible();
-
-        await CustomStatusScreen.close();
-
-        await openSettingsSidebar();
+        // * Check if the selected emoji and text are visible in the sideba
         await expect(element(by.text(customStatus.text).withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
         await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
 
+        // # Tap on the clear custom status button in the sidebar
         await SettingsSidebar.customStatusClearButton.tap();
-        await expect(element(by.text(customStatus.text).withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).not.toBeVisible();
+
+        // * Check if the custom status is cleared and open the modal
+        await expect(element(by.text('Set a Status').withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await CustomStatusScreen.open();
+
+        // * Check if the previously set status is present in the Recents section
+        await expect(element(by.text(customStatus.text).withAncestor(by.id('custom_status.recents')))).toBeVisible();
+
+        // # Tap on the status in the recents section and close the modal by clicking Done button
+        await element(by.text(customStatus.text).withAncestor(by.id('custom_status.recents'))).tap();
+        await CustomStatusScreen.close();
+
+        await openSettingsSidebar();
+
+        // * Check if the status is set and open the modal
+        await expect(element(by.text(customStatus.text).withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
+        await CustomStatusScreen.open();
+
+        // # Tap on the input clear button in the custom status modal
+        await CustomStatusScreen.clearInputButton.tap();
+
+        // * Check if the custom status input and emoji have cleared or not and close the modal
+        await expect(CustomStatusScreen.input).toHaveText('');
+        await expect(CustomStatusScreen.getCustomStatusSelectedEmoji('default')).toBeVisible();
+        await CustomStatusScreen.close();
+
+        await openSettingsSidebar();
+
+        // * Check if the custom status is cleared
+        await expect(element(by.text('Set a Status').withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await expect(element(by.id('custom_status.emoji.default'))).toBeVisible();
+        await ChannelScreen.closeSettingsSidebar();
+    });
+
+    test('MM-T3892 Recent statuses', async () => {
+        // # Open custom status modal and close it after setting the status
+        await openCustomStatusModalAndSetStatus(customStatus);
+        await openSettingsSidebar();
+
+        // * Check if the status is set in the sidebar
+        await expect(element(by.text(customStatus.text).withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await expect(element(by.id(`custom_status.emoji.${customStatus.emojiName}`))).toBeVisible();
+
+        // # Tap on the clear custom status button in the sidebar
+        await SettingsSidebar.customStatusClearButton.tap();
+
+        // * Check if the custom status is cleared and open the modal
+        await expect(element(by.text('Set a Status').withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await CustomStatusScreen.open();
+
+        // * Check if the previously set status is present in the Recents section
+        await expect(element(by.text(customStatus.text).withAncestor(by.id('custom_status.recents')))).toBeVisible();
+
+        // # Tap on the clear button corresponding to the suggestion containing the previously set status
+        await CustomStatusScreen.getSuggestionClearButton(customStatus.text).tap();
+
+        // * Check if the suggestion is removed or not
+        await expect(CustomStatusScreen.getCustomStatusSuggestion(customStatus.text)).not.toExist();
+
+        // # Choose a status from the suggestions and set the status
+        await CustomStatusScreen.tapSuggestion(defaultStatus);
+        await CustomStatusScreen.close();
+
+        await openSettingsSidebar();
+
+        // * Check if the status is set in the sidebar
+        await expect(element(by.text(defaultStatus.text))).toBeVisible();
+        await expect(element(by.id(`custom_status.emoji.${defaultStatus.emoji}`))).toBeVisible();
+
+        // # Tap on the clear custom status button in the sidebar
+        await SettingsSidebar.customStatusClearButton.tap();
+
+        // * Check if the custom status is cleared and open the modal
+        await expect(element(by.text('Set a Status').withAncestor(by.id(SettingsSidebar.testID.customStatusAction)))).toBeVisible();
+        await CustomStatusScreen.open();
+
+        // * The last set status should be present in Recents list and not in the Suggestions list
+        await expect(element(by.text(defaultStatus.text).withAncestor(by.id('custom_status.recents')))).toBeVisible();
+        await expect(element(by.text(defaultStatus.text).withAncestor(by.id('custom_status.suggestions')))).not.toExist();
+
+        // # Tap on the clear button of the suggestion containing the last set status
+        await CustomStatusScreen.getSuggestionClearButton(defaultStatus.text).tap();
+
+        // * The status should be moved from the Recents list to the Suggestions list
+        await expect(element(by.text(defaultStatus.text).withAncestor(by.id('custom_status.recents')))).not.toExist();
+        await expect(element(by.text(defaultStatus.text).withAncestor(by.id('custom_status.suggestions')))).toBeVisible();
+
+        // # Close the modal
+        await CustomStatusScreen.close();
     });
 });
+
+async function openCustomStatusModalAndSetStatus(customStatus) {
+    await openSettingsSidebar();
+
+    // # Click on the Set a custom status option and check if the modal opens
+    await CustomStatusScreen.open();
+
+    // # Type the custom status text in the custom status input
+    await CustomStatusScreen.input.typeText(customStatus.text);
+
+    // * Check if the speech balloon emoji appears when some text is typed in the input
+    await expect(CustomStatusScreen.getCustomStatusSelectedEmoji('speech_balloon')).toBeVisible();
+
+    // # First tap to dismiss the keyboard and then tap again to open the emoji picker
+    await CustomStatusScreen.getCustomStatusSelectedEmoji('speech_balloon').multiTap(2);
+
+    // * Check if the Add reaction screen appears
+    await expect(element(by.id('add_reaction.screen'))).toBeVisible();
+
+    // * Check if the emoji to be selected is present in the emojipicker and select it
+    await expect(element(by.text(customStatus.emoji))).toBeVisible();
+    await element(by.text(customStatus.emoji)).tap();
+
+    // * Check if the Add reaction screen disappears
+    await expect(element(by.id('add_reaction.screen'))).not.toBeVisible();
+
+    // * Check if the selected emoji is visible and close the modal by clicking on Done button
+    await expect(CustomStatusScreen.getCustomStatusSelectedEmoji(customStatus.emojiName)).toBeVisible();
+    await CustomStatusScreen.close();
+}


### PR DESCRIPTION
Added EnableCustomUserStatuses in default config of detox
Added several testIDs in custom status modal and clear button components
Modified settings_sidebar ui component in detox support
Made custom status screen ui screen in detox support
Completed MM-T3890 e2e test
Completed 50% MM-T3891 e2e test

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->