### PR TITLE
Review UI fixes

### DIFF
--- a/app/components/sidebars/settings/drawer_item.js
+++ b/app/components/sidebars/settings/drawer_item.js
@@ -107,10 +107,8 @@ export default class DrawerItem extends PureComponent {
 const getStyleSheet = makeStyleSheetFromTheme((theme) => {
     return {
         container: {
-            alignItems: 'center',
             backgroundColor: theme.centerChannelBg,
             flexDirection: 'row',
-            padding: 3,
             minHeight: 50,
         },
         iconContainer: {
@@ -130,6 +128,8 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         labelContainer: {
             flex: 1,
             justifyContent: 'center',
+            paddingTop: 14,
+            paddingBottom: 14,
         },
         centerLabel: {
             textAlign: 'center',

--- a/app/components/sidebars/settings/settings_sidebar_base.js
+++ b/app/components/sidebars/settings/settings_sidebar_base.js
@@ -430,7 +430,7 @@ const getStyleSheet = makeStyleSheetFromTheme((theme) => {
         },
         clearButton: {
             position: 'absolute',
-            top: 3,
+            top: 4,
             right: 14,
         },
         retryMessage: {

--- a/app/screens/custom_status/custom_status_suggestion.tsx
+++ b/app/screens/custom_status/custom_status_suggestion.tsx
@@ -82,32 +82,30 @@ const getStyleSheet = makeStyleSheetFromTheme((theme: Theme) => {
     return {
         container: {
             backgroundColor: theme.centerChannelBg,
-            display: 'flex',
             flexDirection: 'row',
-            padding: 2,
+            minHeight: 50,
         },
         iconContainer: {
             width: 45,
             height: 46,
             left: 14,
-            top: 8,
+            top: 12,
             marginRight: 6,
             color: theme.centerChannelColor,
         },
         wrapper: {
             flex: 1,
-            position: 'relative',
         },
         textContainer: {
-            marginBottom: 2,
-            alignItems: 'center',
+            paddingTop: 14,
+            paddingBottom: 14,
+            justifyContent: 'center',
             width: '70%',
             flex: 1,
-            flexDirection: 'row',
         },
         clearButtonContainer: {
             position: 'absolute',
-            top: 0,
+            top: 4,
             right: 13,
         },
         divider: {


### PR DESCRIPTION
Changed the padding for custom status both in settings sidebar and custom status suggestions
Changed the position of clear button in the settings sidebar

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```
